### PR TITLE
Move app.languagexchange.net to app.langx.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ LangX is an application built with Angular and Ionic that helps users exchange d
 
 This project is currently in Beta phase v0.7.4 For more information, please refer to the project's GitHub repository.
 
-To check the status of the website, database and CDN, and all clients which are [iOS](https://apps.apple.com/app/languagexchange/id6474187141), [Android](https://play.google.com/store/apps/details?id=tech.newchapter.languageXchange), and [Web App](https://app.languageXchange.net). please visit the following link: https://status.langx.io/
+To check the status of the website, database and CDN, and all clients which are [iOS](https://apps.apple.com/app/languagexchange/id6474187141), [Android](https://play.google.com/store/apps/details?id=tech.newchapter.languageXchange), and [Web App](https://app.langx.io). please visit the following link: https://status.langx.io/
 
 ## Tech Stack
 
@@ -76,7 +76,7 @@ To check the status of the website, database and CDN, and all clients which are 
 - [App Landing Page](https://langx.io/)
 - [iOS App](https://apps.apple.com/us/app/languagexchange/id6474187141)
 - [Android App](https://play.google.com/store/apps/details?id=tech.newchapter.languageXchange)
-- [Web App](https://app.languagexchange.net/)
+- [Web App](https://app.langx.io/)
 
 ## Installation
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="app.languagexchange.net" />
+                <data android:scheme="https" android:host="app.langx.io" />
             </intent-filter>
         </activity>
 

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,13 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:app.languagexchange.net</string>
+		<string>applinks:app.langx.io</string>
 	</array>
 </dict>
 </plist>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -42,6 +42,13 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
+			<key>langx.io</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>

--- a/src/app/components/oauth2/oauth2.component.html
+++ b/src/app/components/oauth2/oauth2.component.html
@@ -33,7 +33,7 @@
       <span style="display: none">Sign in with Google</span>
     </div>
   </button>
-  <button (click)="signInWithFacebook()" class="gsi-material-button">
+  <!-- <button (click)="signInWithFacebook()" class="gsi-material-button">
     <div class="gsi-material-button-state"></div>
     <div class="gsi-material-button-content-wrapper">
       <div class="gsi-material-button-icon">
@@ -67,7 +67,7 @@
       </div>
       <span style="display: none">Sign in with Facebook</span>
     </div>
-  </button>
+  </button> -->
   <button (click)="signInWithApple()" class="gsi-material-button">
     <div class="gsi-material-button-state"></div>
     <div class="gsi-material-button-content-wrapper">

--- a/src/app/components/oauth2/oauth2.component.html
+++ b/src/app/components/oauth2/oauth2.component.html
@@ -33,7 +33,7 @@
       <span style="display: none">Sign in with Google</span>
     </div>
   </button>
-  <!-- <button (click)="signInWithFacebook()" class="gsi-material-button">
+  <button (click)="signInWithFacebook()" class="gsi-material-button">
     <div class="gsi-material-button-state"></div>
     <div class="gsi-material-button-content-wrapper">
       <div class="gsi-material-button-icon">
@@ -67,7 +67,7 @@
       </div>
       <span style="display: none">Sign in with Facebook</span>
     </div>
-  </button> -->
+  </button>
   <button (click)="signInWithApple()" class="gsi-material-button">
     <div class="gsi-material-button-state"></div>
     <div class="gsi-material-button-content-wrapper">


### PR DESCRIPTION
This pull request updates all instances of "app.languagexchange.net" to "app.langx.io" in our codebase. This includes deep link URLs, OAuth redirect URLs, and other relevant URLs. It also adds an exception for "langx.io" for insecure HTTP loads and updates the host URL in AndroidManifest.xml. Additionally, it updates the website and app links in README.md and comments out the Facebook sign-in button in oauth2.component.html. Finally, it removes commented out code for the Facebook sign-in button. This change is part of our rebranding process to align with our new domain name. Fixes #592