### PR TITLE
Fix Discord Bot Sending Updates to #bugs-and-features for Non-Relevant Labels

### DIFF
--- a/.github/workflows/discord_issue_bug_release.yml
+++ b/.github/workflows/discord_issue_bug_release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   send-notification:
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.labels.*.name, 'feature')
+    if: contains(github.event.label.name, 'bug') || contains(github.event.label.name, 'feature')
 
     steps:
       - name: Fetch Issue Details


### PR DESCRIPTION
This pull request fixes the issue where our Discord bot sends updates to the #testers channel whenever any label is added to an issue. The bot will now only send updates to the #testers channel when the @feature or @bug labels are added. This ensures that testers only receive relevant updates. Fixes #593.