### PR TITLE
Fix permission error when archiving rooms

### DIFF
--- a/src/app/services/chat/room.service.ts
+++ b/src/app/services/chat/room.service.ts
@@ -194,29 +194,15 @@ export class RoomService {
   }
 
   archiveRoom(currentUser: User, roomId: string): Observable<User> {
-    return from(
-      this.api.updateDocument(
-        environment.appwrite.USERS_COLLECTION,
-        currentUser.$id,
-        {
-          archivedRooms: [...currentUser?.archivedRooms, roomId],
-        }
-      )
-    );
+    const archivedRooms = [...currentUser?.archivedRooms, roomId];
+    return this.userService.updateUserDoc({ archivedRooms });
   }
 
   unArchiveRoom(currentUser: User, roomId: string): Observable<User> {
-    return from(
-      this.api.updateDocument(
-        environment.appwrite.USERS_COLLECTION,
-        currentUser.$id,
-        {
-          archivedRooms: currentUser?.archivedRooms.filter(
-            (room) => room !== roomId
-          ),
-        }
-      )
+    const archivedRooms = currentUser?.archivedRooms.filter(
+      (room) => room !== roomId
     );
+    return this.userService.updateUserDoc({ archivedRooms });
   }
 
   //


### PR DESCRIPTION
This pull request fixes the permission error that occurs when attempting to archive a room. The issue was caused by incorrect handling of the archivedRooms array in the RoomService class. The code has been updated to properly update the archivedRooms array when archiving or unarchiving a room. This ensures that the room is successfully archived without any permission errors. Fixes #643