### PR TITLE
Use sub-components for rendering partially in chat page

### DIFF
--- a/src/app/components/chat-box/chat-box.component.html
+++ b/src/app/components/chat-box/chat-box.component.html
@@ -103,9 +103,7 @@
             </div>
           </div>
 
-          <span class="message-time">
-            {{ messageTime(msg?.$createdAt) }}
-          </span>
+          <app-timestamp [createdAt]="msg?.$createdAt"></app-timestamp>
         </div>
       </div>
     </div>
@@ -221,17 +219,10 @@
               </ion-buttons>
             </div>
 
-            <span class="message-time" *ngIf="msg?.$createdAt">
-              {{ messageTime(msg?.$createdAt) }}
-              <ion-icon *ngIf="!msg?.seen" name="checkmark-outline"></ion-icon>
-              <ion-icon
-                *ngIf="msg?.seen"
-                name="checkmark-circle-outline"
-              ></ion-icon>
-            </span>
-            <span class="message-time" *ngIf="!msg?.$createdAt">
-              <ion-icon name="cloud-upload-outline"></ion-icon>
-            </span>
+            <app-timestamp
+              [seen]="msg?.seen"
+              [createdAt]="msg?.$createdAt"
+            ></app-timestamp>
           </div>
         </div>
       </div>

--- a/src/app/components/chat-box/chat-box.component.scss
+++ b/src/app/components/chat-box/chat-box.component.scss
@@ -37,17 +37,6 @@ img {
   text-align: left;
 }
 
-.message-time {
-  position: absolute;
-  bottom: 0;
-  right: 1px;
-  font-size: 9px;
-  font-weight: 200;
-  text-align: right;
-  float: right;
-  padding: 5px !important;
-}
-
 .selectable {
   user-select: text;
   -webkit-user-select: text; /* For Safari and Chrome */

--- a/src/app/components/chat-box/chat-box.component.ts
+++ b/src/app/components/chat-box/chat-box.component.ts
@@ -23,7 +23,7 @@ import {
 
 import { MessageService } from 'src/app/services/chat/message.service';
 import { PreviewPhotoComponent } from 'src/app/components/preview-photo/preview-photo.component';
-import { messageTime, urlify } from 'src/app/extras/utils';
+import { urlify } from 'src/app/extras/utils';
 import { Message } from 'src/app/models/Message';
 import { updateMessageRequestInterface } from 'src/app/models/types/requests/updateMessageRequest.interface';
 import { updateMessageAction } from 'src/app/store/actions/message.action';
@@ -352,15 +352,6 @@ export class ChatBoxComponent implements OnInit {
           console.error('Error copying text to clipboard', 'danger');
         });
     }
-  }
-
-  //
-  // Utils for time
-  //
-
-  messageTime(d: any) {
-    if (!d) return null;
-    return messageTime(d);
   }
 
   //

--- a/src/app/components/chat-box/chat-box.component.ts
+++ b/src/app/components/chat-box/chat-box.component.ts
@@ -19,6 +19,8 @@ import {
   ViewChild,
   ChangeDetectorRef,
   ChangeDetectionStrategy,
+  SimpleChanges,
+  OnChanges,
 } from '@angular/core';
 
 import { MessageService } from 'src/app/services/chat/message.service';
@@ -35,7 +37,7 @@ import { messagesSelector } from 'src/app/store/selectors/message.selector';
   styleUrls: ['./chat-box.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ChatBoxComponent implements OnInit {
+export class ChatBoxComponent implements OnInit, OnChanges {
   @ViewChild('itemSlidingSender') itemSlidingSender: IonItemSliding;
   @ViewChild('itemSlidingReveiver') itemSlidingReveiver: IonItemSliding;
 
@@ -72,6 +74,14 @@ export class ChatBoxComponent implements OnInit {
 
   async ngOnInit() {
     await this.initValues();
+    this.changeDetectorRef.detectChanges();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['chat']) {
+      this.msg = { ...this.chat };
+      this.changeDetectorRef.detectChanges();
+    }
   }
 
   ngAfterViewInit() {

--- a/src/app/components/chat-box/chat-box.component.ts
+++ b/src/app/components/chat-box/chat-box.component.ts
@@ -81,6 +81,29 @@ export class ChatBoxComponent implements OnInit, OnChanges {
     if (changes['chat']) {
       this.msg = { ...this.chat };
       this.changeDetectorRef.detectChanges();
+
+      // Check if the message is an image
+      if (this.msg.type === 'image') {
+        if (this.msg.imageId) {
+          this.imageURL$ = this.messageService.getMessageImageView(
+            this.msg.imageId
+          );
+          // Fixing ExpressionChangedAfterItHasBeenCheckedError
+          this.imageURL$.subscribe(() => {
+            console.log('Image URL here !');
+            this.changeDetectorRef.detectChanges();
+          });
+        }
+      }
+
+      // Check if the message is an audio
+      if (this.msg.type === 'audio') {
+        if (this.msg.audioId) {
+          this.audioURL$ = this.messageService.getMessageAudioView(
+            this.msg.audioId
+          );
+        }
+      }
     }
   }
 
@@ -91,35 +114,11 @@ export class ChatBoxComponent implements OnInit, OnChanges {
     });
     this.observer.observe(this.el.nativeElement);
 
-    // Check if the message is an image
     if (this.msg.type === 'image') {
-      if (this.msg.imageId) {
-        this.imageURL$ = this.messageService.getMessageImageView(
-          this.msg.imageId
-        );
-        // Fixing ExpressionChangedAfterItHasBeenCheckedError
-        this.imageURL$.subscribe(() => {
-          this.changeDetectorRef.detectChanges();
-        });
-      } else {
+      if (!this.msg.imageId) {
         // Use a placeholder image URL
         this.msg.type = 'body';
         this.msg.body = '📷 Image Message';
-        this.messageSegments = urlify(this.msg?.body);
-        this.changeDetectorRef.detectChanges();
-      }
-    }
-
-    // Check if the message is an audio
-    if (this.msg.type === 'audio') {
-      if (this.msg.audioId) {
-        this.audioURL$ = this.messageService.getMessageAudioView(
-          this.msg.audioId
-        );
-      } else {
-        // Use a placeholder audio URL
-        this.msg.type = 'body';
-        this.msg.body = '🎵 Audio Message';
         this.messageSegments = urlify(this.msg?.body);
         this.changeDetectorRef.detectChanges();
       }

--- a/src/app/components/chat-box/timestamp/timestamp.component.html
+++ b/src/app/components/chat-box/timestamp/timestamp.component.html
@@ -1,0 +1,8 @@
+<span class="message-time" *ngIf="createdAt">
+  {{ messageTime(createdAt) }}
+  <ion-icon *ngIf="!seen" name="checkmark-outline"></ion-icon>
+  <ion-icon *ngIf="seen" name="checkmark-circle-outline"></ion-icon>
+</span>
+<span class="message-time" *ngIf="!createdAt">
+  <ion-icon name="cloud-upload-outline"></ion-icon>
+</span>

--- a/src/app/components/chat-box/timestamp/timestamp.component.html
+++ b/src/app/components/chat-box/timestamp/timestamp.component.html
@@ -1,7 +1,7 @@
 <span class="message-time" *ngIf="createdAt">
   {{ messageTime(createdAt) }}
-  <ion-icon *ngIf="!seen" name="checkmark-outline"></ion-icon>
-  <ion-icon *ngIf="seen" name="checkmark-circle-outline"></ion-icon>
+  <ion-icon *ngIf="seen === false" name="checkmark-outline"></ion-icon>
+  <ion-icon *ngIf="seen === true" name="checkmark-circle-outline"></ion-icon>
 </span>
 <span class="message-time" *ngIf="!createdAt">
   <ion-icon name="cloud-upload-outline"></ion-icon>

--- a/src/app/components/chat-box/timestamp/timestamp.component.scss
+++ b/src/app/components/chat-box/timestamp/timestamp.component.scss
@@ -1,0 +1,10 @@
+.message-time {
+  position: absolute;
+  bottom: 0;
+  right: 1px;
+  font-size: 9px;
+  font-weight: 200;
+  text-align: right;
+  float: right;
+  padding: 5px !important;
+}

--- a/src/app/components/chat-box/timestamp/timestamp.component.spec.ts
+++ b/src/app/components/chat-box/timestamp/timestamp.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { TimestampComponent } from './timestamp.component';
+
+describe('TimestampComponent', () => {
+  let component: TimestampComponent;
+  let fixture: ComponentFixture<TimestampComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TimestampComponent],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimestampComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/chat-box/timestamp/timestamp.component.ts
+++ b/src/app/components/chat-box/timestamp/timestamp.component.ts
@@ -4,6 +4,7 @@ import {
   OnChanges,
   SimpleChanges,
   ChangeDetectorRef,
+  ChangeDetectionStrategy,
 } from '@angular/core';
 
 import { messageTime } from 'src/app/extras/utils';
@@ -12,6 +13,7 @@ import { messageTime } from 'src/app/extras/utils';
   selector: 'app-timestamp',
   templateUrl: './timestamp.component.html',
   styleUrls: ['./timestamp.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TimestampComponent implements OnChanges {
   @Input() seen: boolean;
@@ -21,10 +23,6 @@ export class TimestampComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['seen'] || changes['createdAt']) {
-      // console.log('createdat:', changes['createdAt'].currentValue);
-      // console.log('seen:', changes['seen'].currentValue);
-
-      // Trigger change detection manually
       this.cdr.detectChanges();
     }
   }

--- a/src/app/components/chat-box/timestamp/timestamp.component.ts
+++ b/src/app/components/chat-box/timestamp/timestamp.component.ts
@@ -21,8 +21,8 @@ export class TimestampComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['seen'] || changes['createdAt']) {
-      console.log('createdat:', changes['createdAt'].currentValue);
-      console.log('seen:', changes['seen'].currentValue);
+      // console.log('createdat:', changes['createdAt'].currentValue);
+      // console.log('seen:', changes['seen'].currentValue);
 
       // Trigger change detection manually
       this.cdr.detectChanges();

--- a/src/app/components/chat-box/timestamp/timestamp.component.ts
+++ b/src/app/components/chat-box/timestamp/timestamp.component.ts
@@ -1,0 +1,40 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  ChangeDetectorRef,
+} from '@angular/core';
+
+import { messageTime } from 'src/app/extras/utils';
+
+@Component({
+  selector: 'app-timestamp',
+  templateUrl: './timestamp.component.html',
+  styleUrls: ['./timestamp.component.scss'],
+})
+export class TimestampComponent implements OnChanges {
+  @Input() seen: boolean;
+  @Input() createdAt: string;
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['seen'] || changes['createdAt']) {
+      console.log('createdat:', changes['createdAt'].currentValue);
+      console.log('seen:', changes['seen'].currentValue);
+
+      // Trigger change detection manually
+      this.cdr.detectChanges();
+    }
+  }
+
+  //
+  // Utils for time
+  //
+
+  messageTime(d: any) {
+    if (!d) return null;
+    return messageTime(d);
+  }
+}

--- a/src/app/components/components.module.ts
+++ b/src/app/components/components.module.ts
@@ -11,6 +11,7 @@ import { UserListComponent } from './user-list/user-list.component';
 import { BlockedUserListComponent } from './blocked-user-list/blocked-user-list.component';
 import { VisitListComponent } from './visit-list/visit-list.component';
 import { StreakListComponent } from './streak-list/streak-list.component';
+import { TimestampComponent } from './chat-box/timestamp/timestamp.component';
 
 @NgModule({
   declarations: [
@@ -23,6 +24,7 @@ import { StreakListComponent } from './streak-list/streak-list.component';
     VisitListComponent,
     StreakListComponent,
     BlockedUserListComponent,
+    TimestampComponent,
   ],
   imports: [CommonModule, IonicModule],
   exports: [
@@ -35,6 +37,7 @@ import { StreakListComponent } from './streak-list/streak-list.component';
     VisitListComponent,
     StreakListComponent,
     BlockedUserListComponent,
+    TimestampComponent,
   ],
 })
 export class ComponentsModule {}

--- a/src/app/pages/home/messages/chat/chat.page.html
+++ b/src/app/pages/home/messages/chat/chat.page.html
@@ -38,7 +38,7 @@
       <ion-item-group
         lines="none"
         class="chats-group"
-        *ngFor="let msg of (messages$ | async)"
+        *ngFor="let msg of (messages$ | async); trackBy: trackByFn"
       >
         <app-chat-box
           [chat]="msg"

--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -847,7 +847,7 @@ export class ChatPage implements OnInit, OnDestroy {
   }
 
   trackByFn(index, item) {
-    return item.$id; // unique id corresponding to the item
+    return item.$id;
   }
 
   //

--- a/src/app/pages/home/messages/chat/chat.page.ts
+++ b/src/app/pages/home/messages/chat/chat.page.ts
@@ -846,6 +846,10 @@ export class ChatPage implements OnInit, OnDestroy {
     this.isCounterShow = this.form.controls['body'].value.length > 400;
   }
 
+  trackByFn(index, item) {
+    return item.$id; // unique id corresponding to the item
+  }
+
   //
   // Present Toast
   //


### PR DESCRIPTION
This pull request implements the use of sub-components for rendering partially within larger components in the chat page. By breaking down larger components into smaller, manageable sub-components, we can render them independently and display content incrementally. This improves performance and user experience, especially for complex components with dynamic content. This pull request also includes other improvements and bug fixes related to the chat UI.

Fixes #634, #399