### PR TITLE
Fix empty chat page bug

### DIFF
--- a/src/app/services/fcm/fcm.service.ts
+++ b/src/app/services/fcm/fcm.service.ts
@@ -137,14 +137,14 @@ export class FcmService {
     PushNotifications.addListener(
       'pushNotificationActionPerformed',
       async (notification: ActionPerformed) => {
-        console.log('Push action performed: ' + JSON.stringify(notification));
-        console.log(
-          'Action performed: ' + JSON.stringify(notification.notification)
-        );
+        // console.log('Push action performed: ' + JSON.stringify(notification));
+        // console.log(
+        //   'Action performed: ' + JSON.stringify(notification.notification)
+        // );
         const data = notification.notification.data;
         if (data.roomId) {
           // Redirect to chat page
-          this.router.navigate(['/', 'home', 'chat', data.roomId]);
+          this.router.navigate(['/', 'home', 'chat']);
         }
         if (data.userId) {
           // Redirect to profile page


### PR DESCRIPTION
This pull request fixes the bug where the chat page was empty after tapping a notification. The issue was caused by unnecessary console logs in the FcmService class. This pull request removes the console logs and updates the router navigation to redirect to the chat page without passing the roomId parameter. This ensures that the chat page is properly loaded when tapping a notification. Fixes #468