### PR TITLE
[Feature] Add pull to refresh for user page

### DIFF
--- a/src/app/pages/home/profile/profile.page.ts
+++ b/src/app/pages/home/profile/profile.page.ts
@@ -210,7 +210,7 @@ export class ProfilePage implements OnInit {
     this.store.dispatch(getCurrentUserAction({ userId: this.currentUserId }));
     this.initValues();
     event.target.complete();
-    console.log('Async operation refresh has ended');
+    // console.log('Async operation refresh has ended');
   }
 
   //

--- a/src/app/pages/home/user/user.page.html
+++ b/src/app/pages/home/user/user.page.html
@@ -18,6 +18,10 @@
   <ion-spinner name="dots"></ion-spinner>
 </ion-content>
 <ion-content class="ion-padding" [fullscreen]="true" *ngIf="!isLoading">
+  <ion-refresher slot="fixed" (ionRefresh)="handleRefresh($event)">
+    <ion-refresher-content></ion-refresher-content>
+  </ion-refresher>
+
   <ion-card>
     <ion-card-header id="profile-pic">
       <img

--- a/src/app/pages/home/user/user.page.html
+++ b/src/app/pages/home/user/user.page.html
@@ -5,7 +5,7 @@
     </ion-buttons>
     <ion-title *ngIf="!isLoading">{{ (user$ | async)?.name }}</ion-title>
     <ion-title *ngIf="isLoading">
-      <ion-spinner name="dots"></ion-spinner>
+      <ion-skeleton-text [animated]="true" style="width: 30%"></ion-skeleton-text>
     </ion-title>
   </ion-toolbar>
 </ion-header>

--- a/src/app/pages/home/user/user.page.html
+++ b/src/app/pages/home/user/user.page.html
@@ -5,7 +5,10 @@
     </ion-buttons>
     <ion-title *ngIf="!isLoading">{{ (user$ | async)?.name }}</ion-title>
     <ion-title *ngIf="isLoading">
-      <ion-skeleton-text [animated]="true" style="width: 30%"></ion-skeleton-text>
+      <ion-skeleton-text
+        [animated]="true"
+        style="width: 30%"
+      ></ion-skeleton-text>
     </ion-title>
   </ion-toolbar>
 </ion-header>
@@ -15,7 +18,39 @@
   class="ion-padding ion-margin"
   style="text-align: center"
 >
-  <ion-spinner name="dots"></ion-spinner>
+  <ion-card>
+    <ion-card-header id="profile-pic">
+      <ion-card-subtitle
+        style="display: flex; justify-content: center; align-items: center"
+      >
+        <ion-skeleton-text
+          [animated]="true"
+          style="width: 200px; height: 200px"
+          class="ion-text-center"
+        ></ion-skeleton-text>
+      </ion-card-subtitle>
+      <ion-card-subtitle
+        style="display: flex; justify-content: center; align-items: center"
+      >
+        <ion-skeleton-text
+          [animated]="true"
+          style="width: 60%"
+        ></ion-skeleton-text>
+      </ion-card-subtitle>
+      <ion-card-subtitle
+        style="display: flex; justify-content: center; align-items: center"
+      >
+        <ion-skeleton-text
+          [animated]="true"
+          style="width: 60%"
+        ></ion-skeleton-text>
+      </ion-card-subtitle>
+    </ion-card-header>
+    <ion-card-content
+      style="display: flex; justify-content: center; align-items: center"
+    >
+    </ion-card-content>
+  </ion-card>
 </ion-content>
 <ion-content class="ion-padding" [fullscreen]="true" *ngIf="!isLoading">
   <ion-refresher slot="fixed" (ionRefresh)="handleRefresh($event)">
@@ -33,7 +68,7 @@
         [class.contributor]="(user$ | async)?.contributors && (user$ | async)?.contributors.length > 0"
         [class.sponsor]="(user$ | async)?.sponsor"
       />
-      <ion-card-title class=".ion-text-center">
+      <ion-card-title class="ion-text-center">
         {{(user$ | async)?.name}}
       </ion-card-title>
       <ion-card-subtitle>

--- a/src/app/pages/home/user/user.page.ts
+++ b/src/app/pages/home/user/user.page.ts
@@ -235,6 +235,13 @@ export class UserPage implements OnInit {
     });
   }
 
+  handleRefresh(event) {
+    this.store.dispatch(getUserByIdAction({ userId: this.userId }));
+    this.initValues();
+    event.target.complete();
+    // console.log('Async operation refresh has ended');
+  }
+
   //
   // Report User
   //


### PR DESCRIPTION
This pull request adds a pull to refresh functionality to the user page, similar to the profile page. It fixes issue #480.

Commits:

- Remove console.log statement from profile.page.ts

- Update user.page.html to use ion-skeleton-text for loading state

- Refactor user page loading state with ion-skeleton-text

Patches:

- Add ion-refresher to user.page.html for pull to refresh functionality

- Remove console.log statement from profile.page.ts

- Update user.page.html to use ion-skeleton-text for loading state

- Refactor user page loading state with ion-skeleton-text