### PR TITLE
Fix bug in deleting other pictures

### DIFF
--- a/src/app/pages/home/profile/settings/edit/edit.page.ts
+++ b/src/app/pages/home/profile/settings/edit/edit.page.ts
@@ -245,7 +245,7 @@ export class EditPage implements OnInit {
 
   async deleteOtherPhotos(image) {
     // get image id from URL
-    image = image.href.split('/files/')[1].split('/view')[0];
+    image = image.href.split('/files/')[1].split('/preview')[0];
 
     const newOtherPics = this.currentUser.otherPics.filter(
       (item) => item !== image


### PR DESCRIPTION
This pull request fixes a bug that occurs when attempting to delete other pictures. The bug was caused by an incorrect URL parsing in the deleteOtherPhotos() function. This PR updates the URL parsing logic to correctly extract the image ID. Fixes #667.